### PR TITLE
New endpoint: Add support for `/api/status/`

### DIFF
--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -1,0 +1,57 @@
+package client
+
+import (
+	"context"
+)
+
+type Status struct {
+	PNGXVersion string         `json:"pngx_version"`
+	ServerOS    string         `json:"server_os"`
+	InstallType string         `json:"install_type"`
+	Storage     StorageStatus  `json:"storage"`
+	Database    DatabaseStatus `json:"database"`
+	Tasks       TasksStatus    `json:"tasks"`
+}
+
+type StorageStatus struct {
+	Total     int64 `json:"total"`
+	Available int64 `json:"available"`
+}
+
+type DatabaseStatus struct {
+	Type            string                  `json:"type"`
+	URL             string                  `json:"url"`
+	Status          string                  `json:"status"`
+	Error           string                  `json:"error"`
+	MigrationStatus DatabaseMigrationStatus `json:"migration_status"`
+}
+
+type DatabaseMigrationStatus struct {
+	LatestMigration     string   `json:"latest_migration"`
+	UnappliedMigrations []string `json:"unapplied_migrations"`
+}
+
+type TasksStatus struct {
+	RedisURL              string `json:"redis_url"`
+	RedisStatus           string `json:"redis_status"`
+	RedisError            string `json:"redis_error"`
+	CeleryStatus          string `json:"celery_status"`
+	IndexStatus           string `json:"index_status"`
+	IndexLastModified     string `json:"index_last_modified"`
+	IndexError            string `json:"index_error"`
+	ClassifierStatus      string `json:"classifier_status"`
+	ClassifierLastTrained string `json:"classifier_last_trained"`
+	ClassifierError       string `json:"classifier_error"`
+}
+
+func (c *Client) GetStatus(ctx context.Context) (*Status, *Response, error) {
+	resp, err := c.newRequest(ctx).
+		SetResult(&Status{}).
+		Get("api/status/")
+
+	if err := convertError(err, resp); err != nil {
+		return nil, wrapResponse(resp), err
+	}
+
+	return resp.Result().(*Status), wrapResponse(resp), nil
+}

--- a/pkg/client/status.go
+++ b/pkg/client/status.go
@@ -4,34 +4,34 @@ import (
 	"context"
 )
 
-type Status struct {
-	PNGXVersion string         `json:"pngx_version"`
-	ServerOS    string         `json:"server_os"`
-	InstallType string         `json:"install_type"`
-	Storage     StorageStatus  `json:"storage"`
-	Database    DatabaseStatus `json:"database"`
-	Tasks       TasksStatus    `json:"tasks"`
+type SystemStatus struct {
+	PNGXVersion string               `json:"pngx_version"`
+	ServerOS    string               `json:"server_os"`
+	InstallType string               `json:"install_type"`
+	Storage     SystemStatusStorage  `json:"storage"`
+	Database    SystemStatusDatabase `json:"database"`
+	Tasks       SystemStatusTasks    `json:"tasks"`
 }
 
-type StorageStatus struct {
+type SystemStatusStorage struct {
 	Total     int64 `json:"total"`
 	Available int64 `json:"available"`
 }
 
-type DatabaseStatus struct {
-	Type            string                  `json:"type"`
-	URL             string                  `json:"url"`
-	Status          string                  `json:"status"`
-	Error           string                  `json:"error"`
-	MigrationStatus DatabaseMigrationStatus `json:"migration_status"`
+type SystemStatusDatabase struct {
+	Type            string                        `json:"type"`
+	URL             string                        `json:"url"`
+	Status          string                        `json:"status"`
+	Error           string                        `json:"error"`
+	MigrationStatus SystemStatusDatabaseMigration `json:"migration_status"`
 }
 
-type DatabaseMigrationStatus struct {
+type SystemStatusDatabaseMigration struct {
 	LatestMigration     string   `json:"latest_migration"`
 	UnappliedMigrations []string `json:"unapplied_migrations"`
 }
 
-type TasksStatus struct {
+type SystemStatusTasks struct {
 	RedisURL              string `json:"redis_url"`
 	RedisStatus           string `json:"redis_status"`
 	RedisError            string `json:"redis_error"`
@@ -44,14 +44,14 @@ type TasksStatus struct {
 	ClassifierError       string `json:"classifier_error"`
 }
 
-func (c *Client) GetStatus(ctx context.Context) (*Status, *Response, error) {
+func (c *Client) GetStatus(ctx context.Context) (*SystemStatus, *Response, error) {
 	resp, err := c.newRequest(ctx).
-		SetResult(&Status{}).
+		SetResult(&SystemStatus{}).
 		Get("api/status/")
 
 	if err := convertError(err, resp); err != nil {
 		return nil, wrapResponse(resp), err
 	}
 
-	return resp.Result().(*Status), wrapResponse(resp), nil
+	return resp.Result().(*SystemStatus), wrapResponse(resp), nil
 }

--- a/pkg/client/status_test.go
+++ b/pkg/client/status_test.go
@@ -1,0 +1,127 @@
+package client
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jarcoal/httpmock"
+)
+
+func TestGetStatus(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		setup   func(*testing.T, *httpmock.MockTransport)
+		wantErr error
+		want    *Status
+	}{
+		{
+			name: "empty",
+			setup: func(t *testing.T, transport *httpmock.MockTransport) {
+				transport.RegisterResponder(http.MethodGet, "/api/status/",
+					httpmock.NewStringResponder(http.StatusOK, `{}`))
+			},
+			want: &Status{},
+		},
+		{
+			name: "bad JSON",
+			setup: func(t *testing.T, transport *httpmock.MockTransport) {
+				transport.RegisterResponder(http.MethodGet, "/api/status/",
+					httpmock.NewStringResponder(http.StatusOK, `{`))
+			},
+			wantErr: cmpopts.AnyError,
+		},
+		{
+			name: "status",
+			setup: func(t *testing.T, transport *httpmock.MockTransport) {
+				transport.RegisterResponder(http.MethodGet, "/api/status/",
+					httpmock.NewStringResponder(http.StatusOK, `{
+						"pngx_version": "2.14.7",
+						"server_os": "Linux-6.8.12-8-pve-x86_64-with-glibc2.36",
+						"install_type": "bare-metal",
+						"storage": {
+							"total": 21474836480,
+							"available": 13406437376
+						},
+						"database": {
+							"type": "postgresql",
+							"url": "paperlessdb",
+							"status": "OK",
+							"error": null,
+							"migration_status": {
+							"latest_migration": "mfa.0003_authenticator_type_uniq",
+							"unapplied_migrations": []
+							}
+						},
+						"tasks": {
+							"redis_url": "redis://localhost:6379",
+							"redis_status": "OK",
+							"redis_error": null,
+							"celery_status": "OK",
+							"index_status": "OK",
+							"index_last_modified": "2025-02-21T00:01:54.773392Z",
+							"index_error": null,
+							"classifier_status": "OK",
+							"classifier_last_trained": "2025-02-21T20:05:01.589548Z",
+							"classifier_error": null
+						}
+						}`))
+			},
+			want: &Status{
+				PNGXVersion: "2.14.7",
+				ServerOS:    "Linux-6.8.12-8-pve-x86_64-with-glibc2.36",
+				InstallType: "bare-metal",
+				Storage: StorageStatus{
+					Total:     21474836480,
+					Available: 13406437376,
+				},
+				Database: DatabaseStatus{
+					Type:   "postgresql",
+					URL:    "paperlessdb",
+					Status: "OK",
+					Error:  "",
+					MigrationStatus: DatabaseMigrationStatus{
+						LatestMigration:     "mfa.0003_authenticator_type_uniq",
+						UnappliedMigrations: []string{},
+					},
+				},
+				Tasks: TasksStatus{
+					RedisURL:              "redis://localhost:6379",
+					RedisStatus:           "OK",
+					RedisError:            "",
+					CeleryStatus:          "OK",
+					IndexStatus:           "OK",
+					IndexLastModified:     "2025-02-21T00:01:54.773392Z",
+					IndexError:            "",
+					ClassifierStatus:      "OK",
+					ClassifierLastTrained: "2025-02-21T20:05:01.589548Z",
+					ClassifierError:       "",
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			transport := newMockTransport(t)
+
+			tc.setup(t, transport)
+
+			c := New(Options{
+				transport: transport,
+			})
+
+			got, _, err := c.GetStatus(context.Background())
+
+			if diff := cmp.Diff(tc.wantErr, err, cmpopts.EquateErrors()); diff != "" {
+				t.Errorf("GetStatus() error diff (-want +got):\n%s", diff)
+			}
+
+			if err == nil {
+				if diff := cmp.Diff(tc.want, got, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("GetStatus() diff (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/pkg/client/status_test.go
+++ b/pkg/client/status_test.go
@@ -15,7 +15,7 @@ func TestGetStatus(t *testing.T) {
 		name    string
 		setup   func(*testing.T, *httpmock.MockTransport)
 		wantErr error
-		want    *Status
+		want    *SystemStatus
 	}{
 		{
 			name: "empty",
@@ -23,7 +23,7 @@ func TestGetStatus(t *testing.T) {
 				transport.RegisterResponder(http.MethodGet, "/api/status/",
 					httpmock.NewStringResponder(http.StatusOK, `{}`))
 			},
-			want: &Status{},
+			want: &SystemStatus{},
 		},
 		{
 			name: "bad JSON",
@@ -69,25 +69,25 @@ func TestGetStatus(t *testing.T) {
 						}
 						}`))
 			},
-			want: &Status{
+			want: &SystemStatus{
 				PNGXVersion: "2.14.7",
 				ServerOS:    "Linux-6.8.12-8-pve-x86_64-with-glibc2.36",
 				InstallType: "bare-metal",
-				Storage: StorageStatus{
+				Storage: SystemStatusStorage{
 					Total:     21474836480,
 					Available: 13406437376,
 				},
-				Database: DatabaseStatus{
+				Database: SystemStatusDatabase{
 					Type:   "postgresql",
 					URL:    "paperlessdb",
 					Status: "OK",
 					Error:  "",
-					MigrationStatus: DatabaseMigrationStatus{
+					MigrationStatus: SystemStatusDatabaseMigration{
 						LatestMigration:     "mfa.0003_authenticator_type_uniq",
 						UnappliedMigrations: []string{},
 					},
 				},
-				Tasks: TasksStatus{
+				Tasks: SystemStatusTasks{
 					RedisURL:              "redis://localhost:6379",
 					RedisStatus:           "OK",
 					RedisError:            "",


### PR DESCRIPTION
This Pull request adds support for the API endpoint `/api/status/`.

See https://github.com/paperless-ngx/paperless-ngx/blob/b40479632b99fdfd3dae6dafb2733b9be09cf012/src/paperless/urls.py#L193-L197

## Testing

### curl

```sh
curl -H "Authorization: Token <token> " http://my.paperless.com:8000/api/status/ | jq
```

```json
{
  "pngx_version": "2.14.7",
  "server_os": "Linux-6.8.12-8-pve-x86_64-with-glibc2.36",
  "install_type": "bare-metal",
  "storage": {
    "total": 21474836480,
    "available": 13406437376
  },
  "database": {
    "type": "postgresql",
    "url": "paperlessdb",
    "status": "OK",
    "error": null,
    "migration_status": {
      "latest_migration": "mfa.0003_authenticator_type_uniq",
      "unapplied_migrations": []
    }
  },
  "tasks": {
    "redis_url": "redis://localhost:6379",
    "redis_status": "OK",
    "redis_error": null,
    "celery_status": "OK",
    "index_status": "OK",
    "index_last_modified": "2025-02-21T00:01:54.773392Z",
    "index_error": null,
    "classifier_status": "OK",
    "classifier_last_trained": "2025-02-21T20:05:01.589548Z",
    "classifier_error": null
  }
}
```

### Go

```go
package main

import (
	"context"
	"fmt"

	"github.com/hansmi/paperhooks/pkg/client"
)

func main() {
		paperlessClient := client.New(client.Options{
		BaseURL: "http://my.paperless.com:8000/",
		Auth: &client.TokenAuth{
			Token: "TOKEN",
		},
	})

	status, resp, err := paperlessClient.GetStatus(context.Background())
	if err != nil {
		panic(err)
	}

	fmt.Printf("Response Code: %d\n", resp.StatusCode)
	fmt.Printf("Statistics (PNGXVersion): %v\n", status.PNGXVersion)
	fmt.Printf("Statistics (ServerOS): %v\n", status.ServerOS)
	fmt.Printf("Statistics (InstallType): %v\n", status.InstallType)
	fmt.Printf("Statistics (Storage.Total): %v\n", status.Storage.Total)
	fmt.Printf("Statistics (Storage.Available): %v\n", status.Storage.Available)
	fmt.Printf("Statistics (Database.Type): %v\n", status.Database.Type)
	fmt.Printf("Statistics (Database.URL): %v\n", status.Database.URL)
	fmt.Printf("Statistics (Database.Status): %v\n", status.Database.Status)
	fmt.Printf("Statistics (Database.Error): %v\n", status.Database.Error)
	fmt.Printf("Statistics (Database.MigrationStatus.LatestMigration): %v\n", status.Database.MigrationStatus.LatestMigration)
	fmt.Printf("Statistics (Database.MigrationStatus.UnappliedMigrations): %v\n", status.Database.MigrationStatus.UnappliedMigrations)
	fmt.Printf("Statistics (Tasks.RedisURL): %v\n", status.Tasks.RedisURL)
	fmt.Printf("Statistics (Tasks.RedisStatus): %v\n", status.Tasks.RedisStatus)
	fmt.Printf("Statistics (Tasks.RedisError): %v\n", status.Tasks.RedisError)
	fmt.Printf("Statistics (Tasks.CeleryStatus): %v\n", status.Tasks.CeleryStatus)
	fmt.Printf("Statistics (Tasks.IndexStatus): %v\n", status.Tasks.IndexStatus)
	fmt.Printf("Statistics (Tasks.IndexLastModified): %v\n", status.Tasks.IndexLastModified)
	fmt.Printf("Statistics (Tasks.IndexError): %v\n", status.Tasks.IndexError)
	fmt.Printf("Statistics (Tasks.ClassifierStatus): %v\n", status.Tasks.ClassifierStatus)
	fmt.Printf("Statistics (Tasks.ClassifierLastTrained): %v\n", status.Tasks.ClassifierLastTrained)
	fmt.Printf("Statistics (Tasks.ClassifierError): %v\n", status.Tasks.ClassifierError)
}

```

Output:
```
Response Code: 200
Statistics (PNGXVersion): 2.14.7
Statistics (ServerOS): Linux-6.8.12-8-pve-x86_64-with-glibc2.36
Statistics (InstallType): bare-metal
Statistics (Storage.Total): 21474836480
Statistics (Storage.Available): 13406437376
Statistics (Database.Type): postgresql
Statistics (Database.URL): paperlessdb
Statistics (Database.Status): OK
Statistics (Database.Error):
Statistics (Database.MigrationStatus.LatestMigration): mfa.0003_authenticator_type_uniq
Statistics (Database.MigrationStatus.UnappliedMigrations): []
Statistics (Tasks.RedisURL): redis://localhost:6379
Statistics (Tasks.RedisStatus): OK
Statistics (Tasks.RedisError):
Statistics (Tasks.CeleryStatus): OK
Statistics (Tasks.IndexStatus): OK
Statistics (Tasks.IndexLastModified): 2025-02-21T00:01:54.773392Z
Statistics (Tasks.IndexError):
Statistics (Tasks.ClassifierStatus): OK
Statistics (Tasks.ClassifierLastTrained): 2025-02-21T21:05:01.580836Z
Statistics (Tasks.ClassifierError):
```

## Pull Request dependency

This Pull Request is having a dependency on https://github.com/hansmi/paperhooks/pull/40.
https://github.com/hansmi/paperhooks/pull/40 needs to be merged before.

## Possible API change incoming

If you look at the current dev branch of Paperless, it looks like the Classifier and Index get its own sub-categories: https://github.com/andygrunwald/paperless-ngx/blob/b40479632b99fdfd3dae6dafb2733b9be09cf012/src/documents/views.py#L2593-L2617

It looks like that with one of the next versions, there might be an API breaking change.

This pull request is based on the latest v2.14.7 of Paperless